### PR TITLE
Fixed issue with invalid CUID when generating v1

### DIFF
--- a/src/main/java/io/github/thibaultmeyer/cuid/CUID.java
+++ b/src/main/java/io/github/thibaultmeyer/cuid/CUID.java
@@ -225,7 +225,7 @@ public final class CUID implements Serializable, Comparable<CUID> {
          */
         private static String getRandomBlock() {
 
-            return Common.padWithZero(Integer.toString(Common.nextIntValue() * DISCRETE_VALUE, NUMBER_BASE), BLOCK_SIZE);
+            return Common.padWithZero(Integer.toString(safeAbs(Common.nextIntValue() * DISCRETE_VALUE), NUMBER_BASE), BLOCK_SIZE);
         }
     }
 

--- a/src/test/java/io/github/thibaultmeyer/cuid/CUIDv1Test.java
+++ b/src/test/java/io/github/thibaultmeyer/cuid/CUIDv1Test.java
@@ -132,4 +132,13 @@ final class CUIDv1Test {
         // Assert
         Assertions.assertEquals(500000, cuidSet.size());
     }
+
+    @Test
+    void validCreation500000() {
+        // Act & Assert
+        for (int i = 0; i < 500000; i += 1) {
+            final CUID cuid = CUID.randomCUID1();
+            Assertions.assertTrue(CUID.isValid(cuid.toString()));
+        }
+    }
 }


### PR DESCRIPTION
It's possible for the following to return false `CUID.isValid(CUID.randomCUID1().toString())` the reason for this is the random number can be a small enough negative number to start the CUID's random bit with a `-`

There is a new test CUIDv1Test#validCreation500000 which highlights the issue, because it's random it may randomly pass, however the 500,000 loops from my testing seems to be enough to get a failure.